### PR TITLE
Process requests on a preemptive CPU stock

### DIFF
--- a/pkg/model/cpu.go
+++ b/pkg/model/cpu.go
@@ -64,7 +64,7 @@ func (cpu *cpuStock) EntitiesInStock() []*simulator.Entity {
 }
 
 func (cpu *cpuStock) KindStocked() simulator.EntityKind {
-	return "Processes"
+	return "Process"
 }
 
 func (cpu *cpuStock) Name() simulator.StockName {

--- a/pkg/model/cpu.go
+++ b/pkg/model/cpu.go
@@ -57,12 +57,10 @@ func (cpu *cpuStock) Count() uint64 {
 }
 
 func (cpu *cpuStock) EntitiesInStock() []*simulator.Entity {
-	es := make([]*simulator.Entity, len(cpu.processes))
-	for i := 0; i < len(cpu.processes); i++ {
-		e := cpu.processes[i]
-		es[i] = &e
-	}
-	return es
+	// TODO: change the interface to return []Entity (an interface),
+	// not []*Entity.
+	panic("not implemented")
+	return nil
 }
 
 func (cpu *cpuStock) KindStocked() simulator.EntityKind {
@@ -73,7 +71,7 @@ func (cpu *cpuStock) Name() simulator.StockName {
 	return "CPU"
 }
 
-func (cpu *cpuStock) Remove() Entity {
+func (cpu *cpuStock) Remove() simulator.Entity {
 	if len(cpu.processes) == 0 {
 		return nil
 	}
@@ -86,7 +84,7 @@ func (cpu *cpuStock) Remove() Entity {
 	return p
 }
 
-func NewCpuStock(env simulator.Env, requestSink simulator.SinkStock) {
+func NewCpuStock(env simulator.Environment, requestSink simulator.SinkStock) *cpuStock {
 	return &cpuStock{
 		env:        env,
 		terminated: requestSink,

--- a/pkg/model/cpu.go
+++ b/pkg/model/cpu.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"fmt"
+	"skenario/pkg/simulator"
+)
+
+type CpuStock interface {
+	simulator.ThroughStock
+}
+
+type cpuStock struct {
+	finished simulator.SinkStock
+	requests []*requestEntity
+}
+
+func (cs *cpuStock) Add(entity simulator.Entity) error {
+	req, ok := entity.(*requestEntity)
+	if !ok {
+		return fmt.Errorf("cpu stock wants requestEntity. got %T", entity)
+	}
+	if len(cs.requests) == 0 {
+		// Schedule the first CPU tick.
+	}
+	cs.requests = append(cs.requests, req)
+	return nil
+}
+
+func (cs *cpuStock) Count() uint64 {
+	return len(requests)
+}
+
+func (cs *cpuStock) EntitiesInStock() []*Entity {
+	return cs.requests
+}
+
+func (cs *cpuStock) KindStocked() EntityKind {
+	return "Requests"
+}
+
+func (cs *cpuStock) Name() StockName {
+	return "CPU"
+}
+
+func (cs *cpuStock) Remove() Entity {
+	cnt := len(cs.requests)
+	if cnt == 0 {
+		return nil
+	}
+	r := cs.requests[0]
+	r.cpuSecondsConsumed += time.Milliseconds * 100
+	cs.requests = cs.requests[1:]
+	if len(cs.requests) != 0 {
+		// Schedule the next CPU tick.
+	}
+	if r.cpuSecondsRequired <= r.cpuSecondsConsumed {
+		// Send the request to the finished sink.
+		// Return the next request in the queue.
+	}
+	return r
+}

--- a/pkg/model/request_entity.go
+++ b/pkg/model/request_entity.go
@@ -70,9 +70,10 @@ func (re *requestEntity) NextBackoff() (backoff time.Duration, outOfAttempts boo
 func NewRequestEntity(env simulator.Environment, buffer RequestsBufferedStock) RequestEntity {
 	reqNumber++
 	return &requestEntity{
-		env:         env,
-		number:      reqNumber,
-		bufferStock: buffer,
-		nextBackoff: 100 * time.Millisecond,
+		env:                env,
+		number:             reqNumber,
+		bufferStock:        buffer,
+		nextBackoff:        100 * time.Millisecond,
+		cpuSecondsRequired: 500 * time.Millisecond,
 	}
 }

--- a/pkg/model/request_entity.go
+++ b/pkg/model/request_entity.go
@@ -17,9 +17,8 @@ package model
 
 import (
 	"fmt"
-	"time"
-
 	"skenario/pkg/simulator"
+	"time"
 )
 
 const backoffMultiplier float64 = 1.3
@@ -39,6 +38,10 @@ type requestEntity struct {
 	bufferStock RequestsBufferedStock
 	nextBackoff time.Duration
 	attempts    int
+
+	// CPU seconds required to complete the request.
+	cpuSecondsRequired time.Duration
+	cpuSecondsConsumed time.Duration
 }
 
 var reqNumber int

--- a/pkg/model/requests_processing.go
+++ b/pkg/model/requests_processing.go
@@ -37,7 +37,7 @@ func (rps *requestsProcessingStock) Name() simulator.StockName {
 }
 
 func (rps *requestsProcessingStock) KindStocked() simulator.EntityKind {
-	return "Requests"
+	return "Request"
 }
 
 func (rps *requestsProcessingStock) Count() uint64 {

--- a/pkg/model/requests_processing.go
+++ b/pkg/model/requests_processing.go
@@ -33,7 +33,7 @@ type requestsProcessingStock struct {
 }
 
 func (rps *requestsProcessingStock) Name() simulator.StockName {
-	return fmt.Sprintf("RequestsProcessing [%d]", rps.replicaNumber)
+	return simulator.StockName(fmt.Sprintf("RequestsProcessing [%d]", rps.replicaNumber))
 }
 
 func (rps *requestsProcessingStock) KindStocked() simulator.EntityKind {
@@ -67,9 +67,8 @@ func (rps *requestsProcessingStock) RequestCount() int32 {
 func NewRequestsProcessingStock(env simulator.Environment, replicaNumber int, requestSink simulator.SinkStock, replicaMaxRPSCapacity int64) RequestsProcessingStock {
 	// TODO: respect replicaMaxRPSCapacity
 	return &requestsProcessingStock{
-		env:              env,
-		replicaNumber:    replicaNumber,
-		requestsComplete: requestSink,
-		cpu:              NewCpuStock(env, requestSink),
+		env:           env,
+		replicaNumber: replicaNumber,
+		cpu:           NewCpuStock(env, requestSink),
 	}
 }


### PR DESCRIPTION
Here is my first attempt at modelling a CPU stock.  Requests keep track of how many CPU seconds they need to complete (initially 500ms) and how many they have been given so far.  Processes (requests) are interrupted every 100ms to schedule another process in a round-robin fashion.

But I think I broke something in the visualization.  This is traffic ramp at HEAD:

![image](https://user-images.githubusercontent.com/1103629/59393773-459f3180-8d7d-11e9-8fe7-c6464b909772.png)

And this is the same ramp with a CPU stock.

![image](https://user-images.githubusercontent.com/1103629/59393735-20aabe80-8d7d-11e9-8eeb-222d94ae512d.png)

@jchesterpivotal why are the RequestsProcessing never going down?  Where does that data come from anyway?  I think my requests are ending since latency stabilizes at 500 ms.