### PR TITLE
Introduce Metrics Lag

### DIFF
--- a/plugin-k8s/go.sum
+++ b/plugin-k8s/go.sum
@@ -531,6 +531,7 @@ github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -582,6 +583,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=

--- a/sim/pkg/data/queries.go
+++ b/sim/pkg/data/queries.go
@@ -29,7 +29,7 @@ select
 		 end)
 	  over summation as tally
 	from completed_movements join stock_aggregate sa on sa.id in (from_stock, to_stock)
-	where kind not in ('start_to_running', 'autoscaler_tick', 'running_to_halted')
+	where kind not in ('start_to_running', 'autoscaler_tick', 'running_to_halted', 'metrics_tick', 'send_metrics_to_pipeline', 'send_metrics_to_sink')
 	and scenario_run_id = ?
     window summation as (partition by sa.name order by occurs_at asc rows unbounded preceding)
 )

--- a/sim/pkg/model/autoscaler_ticktock_test.go
+++ b/sim/pkg/model/autoscaler_ticktock_test.go
@@ -44,7 +44,7 @@ func testAutoscalerTicktock(t *testing.T, describe spec.G, it spec.S) {
 		envFake.TheTime = time.Unix(0, 0)
 
 		replicasConfig = ReplicasConfig{time.Second, time.Second, 100}
-		cluster = NewCluster(envFake, ClusterConfig{}, replicasConfig)
+		cluster = NewCluster(envFake, ClusterConfig{MetricsPipelineLag: 0}, replicasConfig)
 		subject = NewAutoscalerTicktockStock(envFake, simulator.NewEntity("Autoscaler", "HPAAutoscaler"), cluster)
 		rawSubject = subject.(*autoscalerTicktockStock)
 	})

--- a/sim/pkg/model/autoscaler_ticktock_test.go
+++ b/sim/pkg/model/autoscaler_ticktock_test.go
@@ -44,7 +44,7 @@ func testAutoscalerTicktock(t *testing.T, describe spec.G, it spec.S) {
 		envFake.TheTime = time.Unix(0, 0)
 
 		replicasConfig = ReplicasConfig{time.Second, time.Second, 100}
-		cluster = NewCluster(envFake, ClusterConfig{MetricsPipelineLag: 0}, replicasConfig)
+		cluster = NewCluster(envFake, ClusterConfig{}, replicasConfig)
 		subject = NewAutoscalerTicktockStock(envFake, simulator.NewEntity("Autoscaler", "HPAAutoscaler"), cluster)
 		rawSubject = subject.(*autoscalerTicktockStock)
 	})
@@ -132,10 +132,8 @@ func testAutoscalerTicktock(t *testing.T, describe spec.G, it spec.S) {
 
 				it("delegates statistics updating to ClusterModel", func() {
 					stats := envFake.ThePlugin.(*FakePluginPartition).stats
-					assert.Len(t, stats, 3)
+					assert.Len(t, stats, 1)
 					assert.Equal(t, stats[0].Type, proto.MetricType_CONCURRENT_REQUESTS_MILLIS)
-					assert.Equal(t, stats[1].Type, proto.MetricType_CONCURRENT_REQUESTS_MILLIS)
-					assert.Equal(t, stats[2].Type, proto.MetricType_CPU_MILLIS)
 				})
 			})
 

--- a/sim/pkg/model/cluster.go
+++ b/sim/pkg/model/cluster.go
@@ -27,7 +27,6 @@ type ClusterConfig struct {
 	TerminateDelay          time.Duration
 	NumberOfRequests        uint
 	InitialNumberOfReplicas uint
-	MetricsPipelineLag      time.Duration
 }
 
 type ClusterModel interface {
@@ -80,15 +79,6 @@ func (cm *clusterModel) RecordToAutoscaler(atTime *time.Time) {
 	})
 	// TODO: report request count
 
-	// and then report for the replicas
-	for _, e := range cm.replicasActive.EntitiesInStock() {
-		r := (*e).(ReplicaEntity)
-
-		//don't send stats until after at least "metrics pipeline lag"
-		if r.GetCreationTimeStamp().Add(cm.config.MetricsPipelineLag).Before(*atTime) {
-			stats = append(stats, r.Stats()...)
-		}
-	}
 	err := cm.env.Plugin().Stat(stats)
 	if err != nil {
 		panic(err)

--- a/sim/pkg/model/cluster.go
+++ b/sim/pkg/model/cluster.go
@@ -85,7 +85,7 @@ func (cm *clusterModel) RecordToAutoscaler(atTime *time.Time) {
 		r := (*e).(ReplicaEntity)
 
 		//don't send stats until after at least "metrics pipeline lag"
-		if r.GetCreationTimeStamp().Add(cm.config.MetricsPipelineLag).UnixNano() <= atTime.UnixNano() {
+		if r.GetCreationTimeStamp().Add(cm.config.MetricsPipelineLag).Before(*atTime) {
 			stats = append(stats, r.Stats()...)
 		}
 	}

--- a/sim/pkg/model/cluster_test.go
+++ b/sim/pkg/model/cluster_test.go
@@ -121,14 +121,10 @@ func testCluster(t *testing.T, describe spec.G, it spec.S) {
 
 		// TODO immediately record arrivals at routingStock
 
-		it("records once for the routingStock and twice for each replica in ReplicasActive, we have 2 replicas", func() {
+		it("records once for the routingStock", func() {
 			stats := envFake.ThePlugin.(*FakePluginPartition).stats
-			assert.Len(t, envFake.ThePlugin.(*FakePluginPartition).stats, 5)
+			assert.Len(t, envFake.ThePlugin.(*FakePluginPartition).stats, 1)
 			assert.Equal(t, stats[0].Type, proto.MetricType_CONCURRENT_REQUESTS_MILLIS)
-			assert.Equal(t, stats[1].Type, proto.MetricType_CONCURRENT_REQUESTS_MILLIS)
-			assert.Equal(t, stats[2].Type, proto.MetricType_CPU_MILLIS)
-			assert.Equal(t, stats[3].Type, proto.MetricType_CONCURRENT_REQUESTS_MILLIS)
-			assert.Equal(t, stats[4].Type, proto.MetricType_CPU_MILLIS)
 
 		})
 

--- a/sim/pkg/model/fakes.go
+++ b/sim/pkg/model/fakes.go
@@ -81,6 +81,8 @@ type FakeReplica struct {
 	ProcessingStock                    RequestsProcessingStock
 	totalCPUCapacityMillisPerSecond    float64
 	occupiedCPUCapacityMillisPerSecond float64
+	metricsTicktockStock               MetricsTicktockStock
+	creationTimeStamp                  time.Time
 }
 
 func (*FakeReplica) Name() simulator.EntityName {
@@ -117,6 +119,22 @@ func (fr *FakeReplica) Stats() []*proto.Stat {
 
 func (fr *FakeReplica) GetCPUCapacity() float64 {
 	return fr.totalCPUCapacityMillisPerSecond
+}
+
+func (fr *FakeReplica) GetCreationTimeStamp() time.Time {
+	return fr.creationTimeStamp
+}
+
+func (fr *FakeReplica) MetricsTicktock() MetricsTicktockStock {
+	return NewMetricsTickTockStock(NewFakeEnvironment(), fr)
+}
+
+func NewFakeReplica() *FakeReplica {
+	fakeReplica := &FakeReplica{
+		creationTimeStamp: time.Unix(0, 0),
+	}
+	fakeReplica.metricsTicktockStock = NewMetricsTickTockStock(NewFakeEnvironment(), fakeReplica)
+	return fakeReplica
 }
 
 type FakePluginPartition struct {

--- a/sim/pkg/model/fakes.go
+++ b/sim/pkg/model/fakes.go
@@ -82,7 +82,6 @@ type FakeReplica struct {
 	totalCPUCapacityMillisPerSecond    float64
 	occupiedCPUCapacityMillisPerSecond float64
 	metricsTicktockStock               MetricsTicktockStock
-	creationTimeStamp                  time.Time
 }
 
 func (*FakeReplica) Name() simulator.EntityName {
@@ -121,18 +120,12 @@ func (fr *FakeReplica) GetCPUCapacity() float64 {
 	return fr.totalCPUCapacityMillisPerSecond
 }
 
-func (fr *FakeReplica) GetCreationTimeStamp() time.Time {
-	return fr.creationTimeStamp
-}
-
 func (fr *FakeReplica) MetricsTicktock() MetricsTicktockStock {
 	return NewMetricsTickTockStock(NewFakeEnvironment(), fr)
 }
 
 func NewFakeReplica() *FakeReplica {
-	fakeReplica := &FakeReplica{
-		creationTimeStamp: time.Unix(0, 0),
-	}
+	fakeReplica := &FakeReplica{}
 	fakeReplica.metricsTicktockStock = NewMetricsTickTockStock(NewFakeEnvironment(), fakeReplica)
 	return fakeReplica
 }

--- a/sim/pkg/model/metrics_entity.go
+++ b/sim/pkg/model/metrics_entity.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"fmt"
+	"github.com/josephburnett/sk-plugin/pkg/skplug/proto"
+	"skenario/pkg/simulator"
+)
+
+type Metrics interface {
+	GetStats() []*proto.Stat
+}
+
+type MetricsEntity interface {
+	simulator.Entity
+	Metrics
+}
+
+type metricsEntity struct {
+	env    simulator.Environment
+	number int
+	stats  []*proto.Stat
+}
+
+var metricsNum int
+
+func (me *metricsEntity) Name() simulator.EntityName {
+	return simulator.EntityName(fmt.Sprintf("metrics-%d", me.number))
+}
+
+func (me *metricsEntity) Kind() simulator.EntityKind {
+	return "Metrics"
+}
+
+func (me *metricsEntity) GetStats() []*proto.Stat {
+	return me.stats
+}
+
+func NewMetricsEntity(env simulator.Environment, stats []*proto.Stat) MetricsEntity {
+	metricsNum++
+	return &metricsEntity{
+		env:    env,
+		number: metricsNum,
+		stats:  stats,
+	}
+}

--- a/sim/pkg/model/metrics_entity.go
+++ b/sim/pkg/model/metrics_entity.go
@@ -16,7 +16,6 @@ type MetricsEntity interface {
 }
 
 type metricsEntity struct {
-	env    simulator.Environment
 	number int
 	stats  []*proto.Stat
 }
@@ -35,10 +34,9 @@ func (me *metricsEntity) GetStats() []*proto.Stat {
 	return me.stats
 }
 
-func NewMetricsEntity(env simulator.Environment, stats []*proto.Stat) MetricsEntity {
+func NewMetricsEntity(stats []*proto.Stat) MetricsEntity {
 	metricsNum++
 	return &metricsEntity{
-		env:    env,
 		number: metricsNum,
 		stats:  stats,
 	}

--- a/sim/pkg/model/metrics_entity_test.go
+++ b/sim/pkg/model/metrics_entity_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"github.com/josephburnett/sk-plugin/pkg/skplug/proto"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"skenario/pkg/simulator"
+	"testing"
+)
+
+func TestMetricsEntity(t *testing.T) {
+	spec.Run(t, "Metrics Entity", testMetricsEntity, spec.Report(report.Terminal{}))
+}
+
+func testMetricsEntity(t *testing.T, describe spec.G, it spec.S) {
+	var subject MetricsEntity
+	var stats = []*proto.Stat{}
+
+	it.Before(func() {
+		subject = NewMetricsEntity(stats)
+		assert.NotNil(t, subject)
+	})
+
+	describe("NewMetricsEntity()", func() {
+		it("sets stat", func() {
+			assert.Equal(t, stats, subject.GetStats())
+		})
+	})
+
+	describe("Entity interface", func() {
+		it("Name() creates sequential names", func() {
+			beforeName := subject.Name()
+			subject = NewMetricsEntity(stats)
+			afterName := subject.Name()
+			assert.NotEqual(t, beforeName, afterName)
+		})
+
+		it("implements Kind()", func() {
+			assert.Equal(t, simulator.EntityKind("Metrics"), subject.Kind())
+		})
+	})
+}

--- a/sim/pkg/model/metrics_pipeline.go
+++ b/sim/pkg/model/metrics_pipeline.go
@@ -26,7 +26,7 @@ func (mpls *metricsPipelineStock) KindStocked() simulator.EntityKind {
 }
 
 func (mpls *metricsPipelineStock) Count() uint64 {
-	return mpls.Count()
+	return mpls.pipeline.Count()
 }
 
 func (mpls *metricsPipelineStock) EntitiesInStock() []*simulator.Entity {
@@ -56,7 +56,7 @@ func (mpls *metricsPipelineStock) Remove(entity *simulator.Entity) simulator.Ent
 func NewMetricsPipeLineStock(env simulator.Environment) MetricsPipelineStock {
 	return &metricsPipelineStock{
 		env:      env,
-		pipeline: simulator.NewArrayThroughStock("Metrics Pipeline", "Metrics"),
+		pipeline: simulator.NewArrayThroughStock("MetricsPipeline", "Metrics"),
 		sink:     NewMetricsSinkStock(env),
 	}
 }

--- a/sim/pkg/model/metrics_pipeline.go
+++ b/sim/pkg/model/metrics_pipeline.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"skenario/pkg/simulator"
+	"time"
+)
+
+type MetricsPipelineStock interface {
+	simulator.ThroughStock
+}
+
+type metricsPipelineStock struct {
+	env      simulator.Environment
+	pipeline simulator.ThroughStock
+	sink     MetricsSinkStock
+}
+
+var metricsLagDuration = 4 * time.Second
+
+func (mpls *metricsPipelineStock) Name() simulator.StockName {
+	return mpls.pipeline.Name()
+}
+
+func (mpls *metricsPipelineStock) KindStocked() simulator.EntityKind {
+	return mpls.pipeline.KindStocked()
+}
+
+func (mpls *metricsPipelineStock) Count() uint64 {
+	return mpls.Count()
+}
+
+func (mpls *metricsPipelineStock) EntitiesInStock() []*simulator.Entity {
+	return mpls.pipeline.EntitiesInStock()
+}
+
+func (mpls *metricsPipelineStock) Add(entity simulator.Entity) error {
+	err := mpls.pipeline.Add(entity)
+	if err != nil {
+		return err
+	}
+	//get metrics and pass it to sink with a delay
+	mpls.env.AddToSchedule(simulator.NewMovement(
+		"send_metrics_to_sink",
+		mpls.env.CurrentMovementTime().Add(metricsLagDuration),
+		mpls.pipeline,
+		mpls.sink,
+		&entity,
+	))
+	return nil
+}
+
+func (mpls *metricsPipelineStock) Remove(entity *simulator.Entity) simulator.Entity {
+	return mpls.pipeline.Remove(entity)
+}
+
+func NewMetricsPipeLineStock(env simulator.Environment) MetricsPipelineStock {
+	return &metricsPipelineStock{
+		env:      env,
+		pipeline: simulator.NewArrayThroughStock("Metrics Pipeline", "Metrics"),
+		sink:     NewMetricsSinkStock(env),
+	}
+}

--- a/sim/pkg/model/metrics_pipeline_test.go
+++ b/sim/pkg/model/metrics_pipeline_test.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"skenario/pkg/simulator"
+	"testing"
+)
+
+func TestMetricsPipelineStock(t *testing.T) {
+	spec.Run(t, "Metrics Pipeline Stock", testMetricsPipelineStock, spec.Report(report.Terminal{}))
+}
+
+func testMetricsPipelineStock(t *testing.T, describe spec.G, it spec.S) {
+	var subject MetricsPipelineStock
+	var rawSubject *metricsPipelineStock
+	var envFake *FakeEnvironment
+	var metrics MetricsEntity
+
+	it.Before(func() {
+		envFake = NewFakeEnvironment()
+		failedSink := simulator.NewSinkStock("fake-requestsFailed", "Request")
+		replica := NewReplicaEntity(envFake, &failedSink)
+		metrics = NewMetricsEntity(replica.Stats())
+		subject = NewMetricsPipeLineStock(envFake)
+		rawSubject = subject.(*metricsPipelineStock)
+	})
+
+	describe("NewMetricsPipeLineStock", func() {
+		it("sets an environment", func() {
+			assert.Equal(t, envFake, rawSubject.env)
+		})
+
+		it("creates NewMetricsSinkStock", func() {
+			assert.IsType(t, &metricsSinkStock{}, rawSubject.sink)
+		})
+
+		it("creates a pipeline ThroughStock", func() {
+			assert.NotNil(t, rawSubject.pipeline)
+			assert.Equal(t, simulator.StockName("MetricsPipeline"), rawSubject.pipeline.Name())
+			assert.Equal(t, simulator.EntityKind("Metrics"), rawSubject.pipeline.KindStocked())
+		})
+	})
+
+	describe("Name()", func() {
+		it("is called MetricsPipeline", func() {
+			assert.Equal(t, simulator.StockName("MetricsPipeline"), subject.Name())
+		})
+	})
+
+	describe("KindStocked()", func() {
+		it("stocks Metrics", func() {
+			assert.Equal(t, simulator.EntityKind("Metrics"), subject.KindStocked())
+		})
+	})
+
+	describe("Count()", func() {
+		it("gives 0", func() {
+			assert.Zero(t, subject.Count())
+		})
+		it("gives 1", func() {
+			subject.Add(metrics)
+			assert.Equal(t, uint64(1), subject.Count())
+		})
+	})
+
+	describe("EntitiesInStock()", func() {
+		it("empty", func() {
+			assert.Len(t, subject.EntitiesInStock(), 0)
+		})
+		it("has 1 entity", func() {
+			subject.Add(metrics)
+			assert.Len(t, subject.EntitiesInStock(), 1)
+			assert.Equal(t, *subject.EntitiesInStock()[0], metrics)
+
+		})
+	})
+
+	describe("Add()", func() {
+		it.Before(func() {
+			err := subject.Add(metrics)
+			assert.Nil(t, err)
+		})
+
+		it("scheduled a movement send_metrics_to_sink", func() {
+			assert.Equal(t, envFake.Movements[0].Kind(), simulator.MovementKind("send_metrics_to_sink"))
+			assert.IsType(t, &metricsSinkStock{}, envFake.Movements[0].To())
+		})
+	})
+
+	describe("Remove()", func() {
+		it.Before(func() {
+			err := subject.Add(metrics)
+			assert.Nil(t, err)
+		})
+		it("revomes exactly what we put there", func() {
+			assert.Equal(t, subject.Remove(nil), metrics)
+		})
+	})
+}

--- a/sim/pkg/model/metrics_sink.go
+++ b/sim/pkg/model/metrics_sink.go
@@ -1,0 +1,51 @@
+package model
+
+import "skenario/pkg/simulator"
+
+type MetricsSinkStock interface {
+	simulator.SinkStock
+}
+
+type metricsSinkStock struct {
+	env  simulator.Environment
+	sink simulator.SinkStock
+}
+
+func (mss *metricsSinkStock) Name() simulator.StockName {
+	return mss.sink.Name()
+}
+
+func (mss *metricsSinkStock) KindStocked() simulator.EntityKind {
+	return mss.sink.KindStocked()
+}
+
+func (mss *metricsSinkStock) Count() uint64 {
+	return mss.Count()
+}
+
+func (mss *metricsSinkStock) EntitiesInStock() []*simulator.Entity {
+	return mss.sink.EntitiesInStock()
+}
+
+func (mss *metricsSinkStock) Add(entity simulator.Entity) error {
+	err := mss.sink.Add(entity)
+	if err != nil {
+		return err
+	}
+	metrics := entity.(MetricsEntity)
+
+	//pass stats to autoscalers
+	err = mss.env.Plugin().Stat(metrics.GetStats())
+
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func NewMetricsSinkStock(env simulator.Environment) MetricsSinkStock {
+	return &metricsSinkStock{
+		env:  env,
+		sink: simulator.NewSinkStock("Metrics Sink", "Metrics"),
+	}
+}

--- a/sim/pkg/model/metrics_sink.go
+++ b/sim/pkg/model/metrics_sink.go
@@ -20,7 +20,7 @@ func (mss *metricsSinkStock) KindStocked() simulator.EntityKind {
 }
 
 func (mss *metricsSinkStock) Count() uint64 {
-	return mss.Count()
+	return mss.sink.Count()
 }
 
 func (mss *metricsSinkStock) EntitiesInStock() []*simulator.Entity {
@@ -46,6 +46,6 @@ func (mss *metricsSinkStock) Add(entity simulator.Entity) error {
 func NewMetricsSinkStock(env simulator.Environment) MetricsSinkStock {
 	return &metricsSinkStock{
 		env:  env,
-		sink: simulator.NewSinkStock("Metrics Sink", "Metrics"),
+		sink: simulator.NewSinkStock("MetricsSink", "Metrics"),
 	}
 }

--- a/sim/pkg/model/metrics_sink_test.go
+++ b/sim/pkg/model/metrics_sink_test.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"skenario/pkg/simulator"
+	"testing"
+)
+
+func TestMetricsSinkStock(t *testing.T) {
+	spec.Run(t, "Metrics Sink Stock", testMetricsSinkStock, spec.Report(report.Terminal{}))
+}
+
+func testMetricsSinkStock(t *testing.T, describe spec.G, it spec.S) {
+	var subject MetricsSinkStock
+	var rawSubject *metricsSinkStock
+	var envFake *FakeEnvironment
+	var metrics MetricsEntity
+
+	it.Before(func() {
+		envFake = NewFakeEnvironment()
+		failedSink := simulator.NewSinkStock("fake-requestsFailed", "Request")
+		replica := NewReplicaEntity(envFake, &failedSink)
+		metrics = NewMetricsEntity(replica.Stats())
+		subject = NewMetricsSinkStock(envFake)
+		rawSubject = subject.(*metricsSinkStock)
+	})
+
+	describe("NewMetricsSinkStock", func() {
+		it("sets an environment", func() {
+			assert.Equal(t, envFake, rawSubject.env)
+		})
+	})
+
+	describe("Name()", func() {
+		it("is called MetricsSink", func() {
+			assert.Equal(t, simulator.StockName("MetricsSink"), subject.Name())
+		})
+	})
+
+	describe("KindStocked()", func() {
+		it("stocks Metrics", func() {
+			assert.Equal(t, simulator.EntityKind("Metrics"), subject.KindStocked())
+		})
+	})
+
+	describe("Count()", func() {
+		it("gives 0", func() {
+			assert.Zero(t, subject.Count())
+		})
+		it("gives 1", func() {
+			subject.Add(metrics)
+			assert.Equal(t, uint64(1), subject.Count())
+		})
+	})
+
+	describe("EntitiesInStock()", func() {
+		it("empty", func() {
+			assert.Len(t, subject.EntitiesInStock(), 0)
+		})
+		it("has 1 entity", func() {
+			subject.Add(metrics)
+			assert.Len(t, subject.EntitiesInStock(), 1)
+			assert.Equal(t, *subject.EntitiesInStock()[0], metrics)
+
+		})
+	})
+
+	describe("Add()", func() {
+		it.Before(func() {
+			err := subject.Add(metrics)
+			assert.Nil(t, err)
+		})
+
+		it("pass stats to plugin", func() {
+			fakePlugin := envFake.ThePlugin.(*FakePluginPartition)
+			assert.Equal(t, fakePlugin.stats, metrics.GetStats())
+		})
+	})
+}

--- a/sim/pkg/model/metrics_source.go
+++ b/sim/pkg/model/metrics_source.go
@@ -28,7 +28,7 @@ func (mss *metricsSourceStock) EntitiesInStock() []*simulator.Entity {
 }
 
 func (mss *metricsSourceStock) Remove(entity *simulator.Entity) simulator.Entity {
-	return NewMetricsEntity(mss.env, mss.replicaEntity.Stats())
+	return NewMetricsEntity(mss.replicaEntity.Stats())
 }
 
 func NewMetricsSourceStock(env simulator.Environment, replicaEntity ReplicaEntity) MetricsSourceStock {

--- a/sim/pkg/model/metrics_source.go
+++ b/sim/pkg/model/metrics_source.go
@@ -1,0 +1,39 @@
+package model
+
+import "skenario/pkg/simulator"
+
+type MetricsSourceStock interface {
+	simulator.SourceStock
+}
+
+type metricsSourceStock struct {
+	env           simulator.Environment
+	replicaEntity ReplicaEntity
+}
+
+func (mss *metricsSourceStock) Name() simulator.StockName {
+	return "MetricsSource"
+}
+
+func (mss *metricsSourceStock) KindStocked() simulator.EntityKind {
+	return "Metrics"
+}
+
+func (mss *metricsSourceStock) Count() uint64 {
+	return 0
+}
+
+func (mss *metricsSourceStock) EntitiesInStock() []*simulator.Entity {
+	return []*simulator.Entity{}
+}
+
+func (mss *metricsSourceStock) Remove(entity *simulator.Entity) simulator.Entity {
+	return NewMetricsEntity(mss.env, mss.replicaEntity.Stats())
+}
+
+func NewMetricsSourceStock(env simulator.Environment, replicaEntity ReplicaEntity) MetricsSourceStock {
+	return &metricsSourceStock{
+		env:           env,
+		replicaEntity: replicaEntity,
+	}
+}

--- a/sim/pkg/model/metrics_source_test.go
+++ b/sim/pkg/model/metrics_source_test.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"skenario/pkg/simulator"
+	"testing"
+)
+
+func TestMetricsSourceStock(t *testing.T) {
+	spec.Run(t, "Metrics Source Stock", testMetricsSourceStock, spec.Report(report.Terminal{}))
+}
+
+func testMetricsSourceStock(t *testing.T, describe spec.G, it spec.S) {
+	var subject MetricsSourceStock
+	var rawSubject *metricsSourceStock
+	var envFake *FakeEnvironment
+	var replica ReplicaEntity
+
+	it.Before(func() {
+		envFake = NewFakeEnvironment()
+		failedSink := simulator.NewSinkStock("fake-requestsFailed", "Request")
+		replica = NewReplicaEntity(envFake, &failedSink)
+		subject = NewMetricsSourceStock(envFake, replica)
+		rawSubject = subject.(*metricsSourceStock)
+	})
+
+	describe("NewMetricsSourceStock", func() {
+		it("sets an environment", func() {
+			assert.Equal(t, envFake, rawSubject.env)
+		})
+		it("sets a replica", func() {
+			assert.Equal(t, replica, rawSubject.replicaEntity)
+		})
+	})
+
+	describe("Name()", func() {
+		it("is called MetricsSource", func() {
+			assert.Equal(t, simulator.StockName("MetricsSource"), subject.Name())
+		})
+	})
+
+	describe("KindStocked()", func() {
+		it("stocks Metrics", func() {
+			assert.Equal(t, simulator.EntityKind("Metrics"), subject.KindStocked())
+		})
+	})
+
+	describe("Count()", func() {
+		it("gives 0", func() {
+			assert.Zero(t, subject.Count())
+		})
+	})
+
+	describe("EntitiesInStock()", func() {
+		it("always empty", func() {
+			assert.Equal(t, []*simulator.Entity{}, subject.EntitiesInStock())
+		})
+	})
+
+	describe("Remove()", func() {
+		var entity1, entity2 simulator.Entity
+
+		it.Before(func() {
+			entity1 = subject.Remove(nil)
+			assert.NotNil(t, entity1)
+			entity2 = subject.Remove(nil)
+			assert.NotNil(t, entity2)
+		})
+
+		it("creates a new MetricsEntity of EntityKind 'Metrics'", func() {
+			assert.IsType(t, &metricsEntity{}, entity1)
+			assert.Equal(t, simulator.EntityKind("Metrics"), entity1.Kind())
+		})
+	})
+}

--- a/sim/pkg/model/metrics_ticktock.go
+++ b/sim/pkg/model/metrics_ticktock.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"fmt"
+	"skenario/pkg/simulator"
+	"time"
+)
+
+type MetricsTicktockStock interface {
+	simulator.ThroughStock
+}
+
+type metricsTicktockStock struct {
+	env             simulator.Environment
+	replicaEntity   ReplicaEntity
+	metricsSource   simulator.SourceStock
+	metricsPipeline MetricsPipelineStock
+}
+
+var metricsTickInterval = 10 * time.Second
+
+func (mts *metricsTicktockStock) Name() simulator.StockName {
+	return "Metrics Ticktock"
+}
+
+func (mts *metricsTicktockStock) KindStocked() simulator.EntityKind {
+	return "Replica"
+}
+
+func (mts *metricsTicktockStock) Count() uint64 {
+	return 1
+}
+
+func (mts *metricsTicktockStock) EntitiesInStock() []*simulator.Entity {
+	entity := mts.replicaEntity.(simulator.Entity)
+	return []*simulator.Entity{&entity}
+}
+
+func (mts *metricsTicktockStock) Add(entity simulator.Entity) error {
+	if mts.replicaEntity != entity {
+		return fmt.Errorf("'%+v' is different from the entity given at creation time, '%+v'", entity, mts.replicaEntity)
+	}
+
+	mts.env.AddToSchedule(simulator.NewMovement(
+		"send_metrics_to_pipeline",
+		mts.env.CurrentMovementTime().Add(1*time.Nanosecond),
+		mts.metricsSource,
+		mts.metricsPipeline,
+		nil,
+	))
+
+	mts.env.AddToSchedule(simulator.NewMovement(
+		"metrics_tick",
+		mts.env.CurrentMovementTime().Add(metricsTickInterval),
+		mts,
+		mts,
+		&entity,
+	))
+	return nil
+}
+func (mts *metricsTicktockStock) Remove(entity *simulator.Entity) simulator.Entity {
+	return mts.replicaEntity
+}
+
+func NewMetricsTickTockStock(env simulator.Environment, replicaEntity ReplicaEntity) MetricsTicktockStock {
+	return &metricsTicktockStock{
+		env:             env,
+		replicaEntity:   replicaEntity,
+		metricsSource:   NewMetricsSourceStock(env, replicaEntity),
+		metricsPipeline: NewMetricsPipeLineStock(env),
+	}
+}

--- a/sim/pkg/model/metrics_ticktock.go
+++ b/sim/pkg/model/metrics_ticktock.go
@@ -13,7 +13,7 @@ type MetricsTicktockStock interface {
 type metricsTicktockStock struct {
 	env             simulator.Environment
 	replicaEntity   ReplicaEntity
-	metricsSource   simulator.SourceStock
+	metricsSource   MetricsSourceStock
 	metricsPipeline MetricsPipelineStock
 }
 

--- a/sim/pkg/model/metrics_ticktock_test.go
+++ b/sim/pkg/model/metrics_ticktock_test.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/stretchr/testify/assert"
+	"skenario/pkg/simulator"
+	"testing"
+)
+
+func TestMetricsTicktockStock(t *testing.T) {
+	spec.Run(t, "Metrics Ticktock Stock", testMetricsTicktockStock, spec.Report(report.Terminal{}))
+}
+
+func testMetricsTicktockStock(t *testing.T, describe spec.G, it spec.S) {
+	var subject MetricsTicktockStock
+	var rawSubject *metricsTicktockStock
+	var envFake *FakeEnvironment
+	var replica ReplicaEntity
+
+	it.Before(func() {
+		envFake = NewFakeEnvironment()
+		failedSink := simulator.NewSinkStock("fake-requestsFailed", "Request")
+		replica = NewReplicaEntity(envFake, &failedSink)
+		subject = NewMetricsTickTockStock(envFake, replica)
+		rawSubject = subject.(*metricsTicktockStock)
+	})
+
+	describe("NewMetricsTickTockStock", func() {
+		it("sets an environment", func() {
+			assert.Equal(t, envFake, rawSubject.env)
+		})
+
+		it("sets a replica", func() {
+			assert.Equal(t, replica, rawSubject.replicaEntity)
+		})
+	})
+
+	describe("Name()", func() {
+		it("is called Metrics Ticktock", func() {
+			assert.Equal(t, simulator.StockName("Metrics Ticktock"), subject.Name())
+		})
+	})
+
+	describe("KindStocked()", func() {
+		it("stocks Replica", func() {
+			assert.Equal(t, simulator.EntityKind("Replica"), subject.KindStocked())
+		})
+	})
+
+	describe("Count()", func() {
+		it("always has 1 entity stocked", func() {
+			assert.Equal(t, subject.Count(), uint64(1))
+
+			ent := subject.Remove(nil)
+			err := subject.Add(ent)
+			assert.NoError(t, err)
+			err = subject.Add(ent)
+			assert.NoError(t, err)
+
+			assert.Equal(t, subject.Count(), uint64(1))
+
+			subject.Remove(nil)
+			subject.Remove(nil)
+			subject.Remove(nil)
+			assert.Equal(t, subject.Count(), uint64(1))
+		})
+	})
+
+	describe("EntitiesInStock()", func() {
+		it("always has 1 entity stocked\"", func() {
+			assert.Len(t, subject.EntitiesInStock(), 1)
+			assert.Equal(t, *subject.EntitiesInStock()[0], replica)
+
+		})
+	})
+
+	describe("Add()", func() {
+		it.Before(func() {
+			err := subject.Add(replica)
+			assert.Nil(t, err)
+		})
+
+		it("scheduled a movement send_metrics_to_pipeline", func() {
+			assert.Equal(t, envFake.Movements[0].Kind(), simulator.MovementKind("send_metrics_to_pipeline"))
+			assert.IsType(t, &metricsSourceStock{}, envFake.Movements[0].From())
+			assert.IsType(t, &metricsPipelineStock{}, envFake.Movements[0].To())
+		})
+		it("scheduled a movement metrics_tick", func() {
+			assert.Equal(t, envFake.Movements[1].Kind(), simulator.MovementKind("metrics_tick"))
+			assert.IsType(t, &metricsTicktockStock{}, envFake.Movements[1].To())
+			assert.Equal(t, envFake.Movements[1].From(), envFake.Movements[1].To())
+		})
+	})
+
+	describe("Remove()", func() {
+		it("gives back the one Replica", func() {
+			assert.Equal(t, subject.Remove(nil), subject.Remove(nil))
+		})
+	})
+}

--- a/sim/pkg/model/replica_entity.go
+++ b/sim/pkg/model/replica_entity.go
@@ -20,7 +20,6 @@ import (
 	"github.com/josephburnett/sk-plugin/pkg/skplug"
 	"github.com/josephburnett/sk-plugin/pkg/skplug/proto"
 	"skenario/pkg/simulator"
-	"time"
 )
 
 type Replica interface {
@@ -30,7 +29,6 @@ type Replica interface {
 	MetricsTicktock() MetricsTicktockStock
 	Stats() []*proto.Stat
 	GetCPUCapacity() float64
-	GetCreationTimeStamp() time.Time
 }
 
 type ReplicaEntity interface {
@@ -47,7 +45,6 @@ type replicaEntity struct {
 	numRequestsSinceStat               int32
 	totalCPUCapacityMillisPerSecond    float64
 	occupiedCPUCapacityMillisPerSecond float64
-	creationTimeStamp                  time.Time
 	tickTock                           MetricsTicktockStock
 }
 
@@ -121,10 +118,6 @@ func (re *replicaEntity) GetCPUCapacity() float64 {
 	return re.totalCPUCapacityMillisPerSecond
 }
 
-func (re *replicaEntity) GetCreationTimeStamp() time.Time {
-	return re.creationTimeStamp
-}
-
 func NewReplicaEntity(env simulator.Environment, failedSink *simulator.SinkStock) ReplicaEntity {
 	replicaNum++
 
@@ -134,8 +127,6 @@ func NewReplicaEntity(env simulator.Environment, failedSink *simulator.SinkStock
 		totalCPUCapacityMillisPerSecond:    1000,
 		occupiedCPUCapacityMillisPerSecond: 0,
 	}
-
-	re.creationTimeStamp = re.env.CurrentMovementTime()
 	re.requestsComplete = simulator.NewSinkStock(simulator.StockName(fmt.Sprintf("RequestsComplete [%d]", re.number)), "Request")
 	re.requestsProcessing = NewRequestsProcessingStock(env, re.number, re.requestsComplete, failedSink, &re.totalCPUCapacityMillisPerSecond, &re.occupiedCPUCapacityMillisPerSecond)
 	re.tickTock = NewMetricsTickTockStock(env, re)

--- a/sim/pkg/model/replica_entity.go
+++ b/sim/pkg/model/replica_entity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/josephburnett/sk-plugin/pkg/skplug"
 	"github.com/josephburnett/sk-plugin/pkg/skplug/proto"
 	"skenario/pkg/simulator"
+	"time"
 )
 
 type Replica interface {
@@ -28,6 +29,7 @@ type Replica interface {
 	RequestsProcessing() RequestsProcessingStock
 	Stats() []*proto.Stat
 	GetCPUCapacity() float64
+	GetCreationTimeStamp() time.Time
 }
 
 type ReplicaEntity interface {
@@ -44,6 +46,7 @@ type replicaEntity struct {
 	numRequestsSinceStat               int32
 	totalCPUCapacityMillisPerSecond    float64
 	occupiedCPUCapacityMillisPerSecond float64
+	creationTimeStamp                  time.Time
 }
 
 var replicaNum int
@@ -112,6 +115,10 @@ func (re *replicaEntity) GetCPUCapacity() float64 {
 	return re.totalCPUCapacityMillisPerSecond
 }
 
+func (re *replicaEntity) GetCreationTimeStamp() time.Time {
+	return re.creationTimeStamp
+}
+
 func NewReplicaEntity(env simulator.Environment, failedSink *simulator.SinkStock) ReplicaEntity {
 	replicaNum++
 
@@ -122,6 +129,7 @@ func NewReplicaEntity(env simulator.Environment, failedSink *simulator.SinkStock
 		occupiedCPUCapacityMillisPerSecond: 0,
 	}
 
+	re.creationTimeStamp = re.env.CurrentMovementTime()
 	re.requestsComplete = simulator.NewSinkStock(simulator.StockName(fmt.Sprintf("RequestsComplete [%d]", re.number)), "Request")
 	re.requestsProcessing = NewRequestsProcessingStock(env, re.number, re.requestsComplete, failedSink, &re.totalCPUCapacityMillisPerSecond, &re.occupiedCPUCapacityMillisPerSecond)
 

--- a/sim/pkg/model/replica_entity.go
+++ b/sim/pkg/model/replica_entity.go
@@ -27,6 +27,7 @@ type Replica interface {
 	Activate()
 	Deactivate()
 	RequestsProcessing() RequestsProcessingStock
+	MetricsTicktock() MetricsTicktockStock
 	Stats() []*proto.Stat
 	GetCPUCapacity() float64
 	GetCreationTimeStamp() time.Time
@@ -47,6 +48,7 @@ type replicaEntity struct {
 	totalCPUCapacityMillisPerSecond    float64
 	occupiedCPUCapacityMillisPerSecond float64
 	creationTimeStamp                  time.Time
+	tickTock                           MetricsTicktockStock
 }
 
 var replicaNum int
@@ -77,6 +79,10 @@ func (re *replicaEntity) Deactivate() {
 
 func (re *replicaEntity) RequestsProcessing() RequestsProcessingStock {
 	return re.requestsProcessing
+}
+
+func (re *replicaEntity) MetricsTicktock() MetricsTicktockStock {
+	return re.tickTock
 }
 
 func (re *replicaEntity) Stats() []*proto.Stat {
@@ -125,13 +131,13 @@ func NewReplicaEntity(env simulator.Environment, failedSink *simulator.SinkStock
 	re := &replicaEntity{
 		env:                                env,
 		number:                             replicaNum,
-		totalCPUCapacityMillisPerSecond:    100,
+		totalCPUCapacityMillisPerSecond:    1000,
 		occupiedCPUCapacityMillisPerSecond: 0,
 	}
 
 	re.creationTimeStamp = re.env.CurrentMovementTime()
 	re.requestsComplete = simulator.NewSinkStock(simulator.StockName(fmt.Sprintf("RequestsComplete [%d]", re.number)), "Request")
 	re.requestsProcessing = NewRequestsProcessingStock(env, re.number, re.requestsComplete, failedSink, &re.totalCPUCapacityMillisPerSecond, &re.occupiedCPUCapacityMillisPerSecond)
-
+	re.tickTock = NewMetricsTickTockStock(env, re)
 	return re
 }

--- a/sim/pkg/model/replicas_active.go
+++ b/sim/pkg/model/replicas_active.go
@@ -17,6 +17,7 @@ package model
 
 import (
 	"skenario/pkg/simulator"
+	"time"
 )
 
 type ReplicasActiveStock interface {
@@ -58,6 +59,12 @@ func (ras *replicasActiveStock) Remove(entity *simulator.Entity) simulator.Entit
 func (ras *replicasActiveStock) Add(entity simulator.Entity) error {
 	replica := entity.(Replica)
 	replica.Activate()
+	ras.env.AddToSchedule(simulator.NewMovement(
+		"metrics_tick",
+		ras.env.CurrentMovementTime().Add(5*time.Second),
+		replica.MetricsTicktock(),
+		replica.MetricsTicktock(),
+		&entity))
 	return ras.delegate.Add(entity)
 }
 

--- a/sim/pkg/model/replicas_active_test.go
+++ b/sim/pkg/model/replicas_active_test.go
@@ -54,7 +54,7 @@ func testReplicasActive(t *testing.T, describe spec.G, it spec.S) {
 		var replicaFake *FakeReplica
 
 		it.Before(func() {
-			replicaFake = new(FakeReplica)
+			replicaFake = NewFakeReplica()
 			subject.Add(replicaFake)
 		})
 
@@ -83,7 +83,7 @@ func testReplicasActive(t *testing.T, describe spec.G, it spec.S) {
 		var entity simulator.Entity
 
 		it.Before(func() {
-			replicaFake = new(FakeReplica)
+			replicaFake = NewFakeReplica()
 			subject.Add(replicaFake)
 			entity = simulator.Entity(replicaFake)
 			subject.Remove(&entity)

--- a/sim/pkg/model/replicas_active_test.go
+++ b/sim/pkg/model/replicas_active_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestReplicasActive(t *testing.T) {
-	spec.Run(t, "Replicas Active spec", testReplicasActive, spec.Report(report.Terminal{}))
+	spec.Run(t, "Replicas Active stock", testReplicasActive, spec.Report(report.Terminal{}))
 }
 
 func testReplicasActive(t *testing.T, describe spec.G, it spec.S) {

--- a/sim/pkg/model/replicas_terminating_test.go
+++ b/sim/pkg/model/replicas_terminating_test.go
@@ -39,7 +39,7 @@ func testReplicasTerminating(t *testing.T, describe spec.G, it spec.S) {
 
 	it.Before(func() {
 		envFake = NewFakeEnvironment()
-		replicaFake = new(FakeReplica)
+		replicaFake = NewFakeReplica()
 		config = ReplicasConfig{LaunchDelay: 111 * time.Nanosecond, TerminateDelay: 222 * time.Nanosecond}
 		terminatedStock = simulator.NewSinkStock("ReplicasTerminated", "Replica")
 		subject = NewReplicasTerminatingStock(envFake, config, terminatedStock)

--- a/sim/pkg/model/requests_routing_test.go
+++ b/sim/pkg/model/requests_routing_test.go
@@ -65,15 +65,15 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 
 				replicaStock = NewReplicasActiveStock(envFake)
 
-				replicaFake = new(FakeReplica)
+				replicaFake = NewFakeReplica()
 				replicaFake.FakeReplicaNum = 11
 				replicaStock.Add(replicaFake)
 
-				replicaFake = new(FakeReplica)
+				replicaFake = NewFakeReplica()
 				replicaFake.FakeReplicaNum = 22
 				replicaStock.Add(replicaFake)
 
-				replicaFake = new(FakeReplica)
+				replicaFake = NewFakeReplica()
 				replicaFake.FakeReplicaNum = 33
 				replicaStock.Add(replicaFake)
 
@@ -85,8 +85,8 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 			})
 
 			it("assigns the Requests to Replicas using round robin", func() {
-				first := envFake.Movements[1]
-				second := envFake.Movements[2]
+				first := envFake.Movements[4]
+				second := envFake.Movements[5]
 
 				assert.Equal(t, simulator.MovementKind("send_to_replica"), first.Kind())
 				assert.Equal(t, simulator.MovementKind("send_to_replica"), second.Kind())
@@ -101,7 +101,7 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 					request = NewRequestEntity(envFake, subject, RequestConfig{CPUTimeMillis: 200, IOTimeMillis: 200, Timeout: 1 * time.Second})
 
 					replicaStock = NewReplicasActiveStock(envFake)
-					replicaFake = new(FakeReplica)
+					replicaFake = NewFakeReplica()
 					replicaStock.Add(replicaFake)
 
 					subject = NewRequestsRoutingStock(envFake, replicaStock, requestsFailedStock)
@@ -110,8 +110,8 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 				})
 
 				it("schedules the Request to move to a Replica for processing", func() {
-					assert.Equal(t, simulator.StockName("RequestsRouting"), envFake.Movements[0].From().Name())
-					assert.Contains(t, string(envFake.Movements[0].To().Name()), "RequestsProcessing")
+					assert.Equal(t, simulator.StockName("RequestsRouting"), envFake.Movements[1].From().Name())
+					assert.Contains(t, string(envFake.Movements[1].To().Name()), "RequestsProcessing")
 				})
 			})
 		})

--- a/sim/pkg/model/requests_routing_test.go
+++ b/sim/pkg/model/requests_routing_test.go
@@ -84,6 +84,12 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 				subject.Add(NewRequestEntity(envFake, subject, RequestConfig{CPUTimeMillis: 200, IOTimeMillis: 200, Timeout: 1 * time.Second}))
 			})
 
+			it("schedules metrics_tick for replicas, as we have 3 active replicas, we end up with 3 merics_tick", func() {
+				assert.Equal(t, simulator.MovementKind("metrics_tick"), envFake.Movements[0].Kind())
+				assert.Equal(t, simulator.MovementKind("metrics_tick"), envFake.Movements[1].Kind())
+				assert.Equal(t, simulator.MovementKind("metrics_tick"), envFake.Movements[2].Kind())
+			})
+
 			it("assigns the Requests to Replicas using round robin", func() {
 				first := envFake.Movements[4]
 				second := envFake.Movements[5]
@@ -108,7 +114,9 @@ func testRequestsRouting(t *testing.T, describe spec.G, it spec.S) {
 
 					subject.Add(request)
 				})
-
+				it("schedules metrics_tick for a replica", func() {
+					assert.Equal(t, simulator.MovementKind("metrics_tick"), envFake.Movements[0].Kind())
+				})
 				it("schedules the Request to move to a Replica for processing", func() {
 					assert.Equal(t, simulator.StockName("RequestsRouting"), envFake.Movements[1].From().Name())
 					assert.Contains(t, string(envFake.Movements[1].To().Name()), "RequestsProcessing")

--- a/sim/pkg/model/trafficpatterns/ramp.go
+++ b/sim/pkg/model/trafficpatterns/ramp.go
@@ -27,13 +27,13 @@ type ramp struct {
 	source       model.TrafficSource
 	routingStock model.RequestsRoutingStock
 	sink         model.RequestsProcessingStock
-	deltaV       int
+	deltaV       float64
 	maxRPS       int
 }
 
 type RampConfig struct {
-	DeltaV int `json:"delta_v"`
-	MaxRPS int `json:"max_rps"`
+	DeltaV float64 `json:"delta_v"`
+	MaxRPS int     `json:"max_rps"`
 }
 
 func (*ramp) Name() string {
@@ -45,9 +45,9 @@ func (r *ramp) Generate() {
 	nextRPS := r.deltaV
 	startAt := r.env.CurrentMovementTime()
 
-	for t = startAt; nextRPS <= r.maxRPS; t = t.Add(1 * time.Second) {
+	for t = startAt; int(nextRPS) <= r.maxRPS; t = t.Add(1 * time.Second) {
 		uniRand := NewUniformRandom(r.env, r.source, r.routingStock, UniformConfig{
-			NumberOfRequests: nextRPS,
+			NumberOfRequests: int(nextRPS),
 			StartAt:          t,
 			RunFor:           time.Second,
 		})
@@ -58,7 +58,7 @@ func (r *ramp) Generate() {
 	for ; nextRPS > 0; t = t.Add(1 * time.Second) {
 		nextRPS = nextRPS - r.deltaV
 		uniRand := NewUniformRandom(r.env, r.source, r.routingStock, UniformConfig{
-			NumberOfRequests: nextRPS,
+			NumberOfRequests: int(nextRPS),
 			StartAt:          t,
 			RunFor:           time.Second,
 		})

--- a/sim/pkg/serve/index.html
+++ b/sim/pkg/serve/index.html
@@ -203,7 +203,7 @@ spec:
                             <label class="label" for="rampConfigDeltaV">Ramp Delta V</label>
                         </div>
                         <div class="control">
-                            <input type="number" style="width: 5em" id="rampConfigDeltaV" value="1" min="1" step="1"/>
+                            <input type="number" style="width: 5em" id="rampConfigDeltaV" value="1" min="0.1" step="0.1"/>
                         </div>
                     </div>
                     <div class="field is-horizontal">
@@ -520,7 +520,7 @@ spec:
                 break;
             case "ramp":
                 let rampConfigMaxRPS = parseInt(document.querySelector("input[id='rampConfigMaxRPS']").value);
-                let rampConfigDeltaV = parseInt(document.querySelector("input[id='rampConfigDeltaV']").value);
+                let rampConfigDeltaV = parseFloat(document.querySelector("input[id='rampConfigDeltaV']").value);
 
                 skenarioRunRequest["ramp_config"] = {
                     delta_v: rampConfigDeltaV,

--- a/sim/pkg/serve/run_handler.go
+++ b/sim/pkg/serve/run_handler.go
@@ -349,6 +349,7 @@ func buildClusterConfig(srr *SkenarioRunRequest) model.ClusterConfig {
 		TerminateDelay:          srr.TerminateDelay,
 		NumberOfRequests:        uint(srr.UniformConfig.NumberOfRequests),
 		InitialNumberOfReplicas: srr.InitialNumberOfReplicas,
+		MetricsPipelineLag:      1 * time.Millisecond,
 	}
 }
 

--- a/sim/pkg/serve/run_handler.go
+++ b/sim/pkg/serve/run_handler.go
@@ -349,7 +349,7 @@ func buildClusterConfig(srr *SkenarioRunRequest) model.ClusterConfig {
 		TerminateDelay:          srr.TerminateDelay,
 		NumberOfRequests:        uint(srr.UniformConfig.NumberOfRequests),
 		InitialNumberOfReplicas: srr.InitialNumberOfReplicas,
-		MetricsPipelineLag:      1 * time.Millisecond,
+		MetricsPipelineLag:      10 * time.Second,
 	}
 }
 

--- a/sim/pkg/serve/run_handler.go
+++ b/sim/pkg/serve/run_handler.go
@@ -349,7 +349,6 @@ func buildClusterConfig(srr *SkenarioRunRequest) model.ClusterConfig {
 		TerminateDelay:          srr.TerminateDelay,
 		NumberOfRequests:        uint(srr.UniformConfig.NumberOfRequests),
 		InitialNumberOfReplicas: srr.InitialNumberOfReplicas,
-		MetricsPipelineLag:      10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Currently Skenario gets metrics from a replica now and passes to autoscaler now. 
This change introduces  a new way to send metrics: get them from a replica now and pass to autoscaler later. The data is stale by metrics lag time, which is usual thing in reality.
In real life the metric freshness of each replica will vary slightly. Therefore every replica has its own tick tock mechanism. Metrics for each replica will be passed to autoscaler independently from each other, depending on when its tick tock were started.