### PR TITLE
Fix Initial number of replicas

### DIFF
--- a/sim/pkg/model/autoscaler.go
+++ b/sim/pkg/model/autoscaler.go
@@ -62,14 +62,20 @@ func NewAutoscaler(env simulator.Environment, startAt time.Time, cluster Cluster
 	}
 
 	// TODO: create initial replicas config.
-	// Create the first pod since HPA can't scale from zero.
+	// Create the first pods since HPA can't scale from zero.
 	cm := cluster.(*clusterModel)
-	rs := cm.replicaSource.(*replicaSource)
-	err = cm.replicasActive.Add(NewReplicaEntity(rs.env, &rs.failedSink))
-	if err != nil {
-		panic(err)
-	}
+	for i := 0; i < int(cm.config.InitialNumberOfReplicas); i++ {
+		replica := NewReplicaEntity(env, &cm.replicaSource.(*replicaSource).failedSink).(simulator.Entity)
+		cm.replicasLaunching.Add(replica)
+		env.AddToSchedule(simulator.NewMovement(
+			"start_initial_replica",
+			startAt.Add(time.Nanosecond),
+			cm.replicasLaunching,
+			cm.replicasActive,
+			&replica,
+		))
 
+	}
 	as := &autoscaler{
 		env:      env,
 		tickTock: NewAutoscalerTicktockStock(env, autoscalerEntity, cluster),


### PR DESCRIPTION
Currently, Skenario starts simulation from one replica. It's exactly what we need in HPA. But in order to introduce VPA, it's essential to to set the number of replicas themselves. Also, this PR fixes the case, when we have only one replica and see not a single one in UI. 