### PR TITLE
Support remove of specific entity in ReplicaSource

### DIFF
--- a/sim/pkg/model/replicas_source.go
+++ b/sim/pkg/model/replicas_source.go
@@ -46,6 +46,9 @@ func (rs *replicaSource) EntitiesInStock() []*simulator.Entity {
 }
 
 func (rs *replicaSource) Remove(entity *simulator.Entity) simulator.Entity {
+	if entity != nil {
+		return *entity
+	}
 	return NewReplicaEntity(rs.env, &rs.failedSink)
 }
 


### PR DESCRIPTION
Currently calling Remove in ReplicaSource returns a new replica always with the same parameters (i.e. cpu capacity). It's okay for HPA semantics to create always identical replicas. However, to add VPA semantics, Remove in ReplicaSource should return a specific entity according to VPA recommendations.  