### PR TITLE
Fix a bug in ReplicasDesiredStock 

### DIFF
--- a/sim/pkg/model/replicas_desired.go
+++ b/sim/pkg/model/replicas_desired.go
@@ -77,7 +77,7 @@ func (rds *replicasDesiredStock) Remove(entity *simulator.Entity) simulator.Enti
 			nextTerminate,
 			rds.replicasLaunching,
 			rds.replicasTerminating,
-			&ent,
+			nil,
 		))
 	} else {
 		rds.env.AddToSchedule(simulator.NewMovement(
@@ -85,7 +85,7 @@ func (rds *replicasDesiredStock) Remove(entity *simulator.Entity) simulator.Enti
 			nextTerminate,
 			rds.replicasActive,
 			rds.replicasTerminating,
-			&ent,
+			nil,
 		))
 	}
 


### PR DESCRIPTION
This PR fixes the bug related to terminating replicas logic when we scale down. This bug was caused we did the movements of entities specific and introduced the opportunity to remove a particular entity.  